### PR TITLE
Compatibility with tile gaps

### DIFF
--- a/CHANGELOG (Case Conflict).bbcode
+++ b/CHANGELOG (Case Conflict).bbcode
@@ -1,0 +1,43 @@
+# Changelog
+
+
+## 1.0.1
+
+* fixed:
+  * KWin 5.22 compatibility issues
+
+
+## 1.0
+
+* new:
+  * configuration dialog
+  * configurable transparency of unaffected windows
+  * configurable threshold defining a maximal distance to consider edges as snapped
+  * option to ignore maximized windows
+  * option to ignore window edges that touch an edge of the screen
+  * restore affected minimized windows temporarily
+* changed:
+  * highlight a snapped window only when its size is changed
+  * also consider windows that are on all desktops
+  * delay transparency changes until first resize step to prevent flickering
+  * do not restrict a window to the client area (typically the screen size) if it already exceeds it
+* fixed:
+  * crash on resize when a snapped window disappears
+
+
+## 0.2.1
+
+* fixed resizing for windows spanning multiple screens
+
+
+## 0.2
+
+* maximized windows are ignored now
+* shaded windows are ignored now
+* windows on other screens are ignored now
+* changed behavior when windows get very small while resizing
+
+
+## 0.1
+
+* initial release

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flupp/sticky-window-snapping) modified for compatibility with my [Tile Gaps](https://github.com/nclarius/tile-gaps). This version adds an option in the configuration to set the tile gap size between windows, and will properly retain the gap when resizing adjacent windows.
 
-
-
 ## Installation
 
 1. Clone the repository (top right green button *Code* > *Download ZIP* > unpack, or `git clone https://github.com/nclarius/sticky-window-snapping.git`).
@@ -14,6 +12,10 @@ This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flup
 *System Settings* > *Window Management* > *KWin scripts* > settings wheel for the script.
 
 You may need to disable and re-enable the script (using the checkbox) in order for the changes to take effect.
+
+## 
+
+N.C.
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flup
 
 ## Configuration
 
-*System Settings* > *Window Management* > *KWin scripts* > settings wheel for the script.
+*System Settings* > *Window Management* > *KWin Scripts* > settings button for the script.
 
 You may need to disable and re-enable the script (using the checkbox) in order for the changes to take effect.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flup
 ## Installation
 
 1. Clone the repository (top right green button *Code* > *Download ZIP* > unpack, or `git clone https://github.com/nclarius/sticky-window-snapping.git`).
-2. Change into the folder, and run `kpackagetool-install.bash` (click on the file > *Execute*, or `./kpackagetooll-install.sh`).
+2. Change into the folder, and run `kpackagetool-install.bash` (click on the file > *Execute*, or `./kpackagetooll-install.bash`).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Sticky Window Snapping
 
+This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flupp/sticky-window-snapping) modified for compatibility with my [Tile Gaps](https://github.com/nclarius/tile-gaps). This version adds an option in the configuration to set the tile gap size between windows, and will properly retain the gap when resizing adjacent windows.
+
+<hr>
+
 KWin script to let snapped window edges stick together when one window is resized.
 
 The script provides an easy to use configuration dialog, which can be reached via `systemsettings`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flup
 ## Installation
 
 1. Clone the repository (top right green button *Code* > *Download ZIP* > unpack, or `git clone https://github.com/nclarius/sticky-window-snapping.git`).
-2. Change into the folder, and run `kpackagetool-install.bash` (click on the file > *Execute*, or `./kpackagetooll-install.bash`).
+2. Change into the folder, and run `kpackagetool-install.bash` (click on the file > *Execute*, or `./kpackagetool-install.bash`).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This is a fork of Toni Dietze's [Sticky Window Snapping](https://github.com/Flupp/sticky-window-snapping) modified for compatibility with my [Tile Gaps](https://github.com/nclarius/tile-gaps). This version adds an option in the configuration to set the tile gap size between windows, and will properly retain the gap when resizing adjacent windows.
 
+
+
+## Installation
+
+1. Clone the repository (top right green button *Code* > *Download ZIP* > unpack, or `git clone https://github.com/nclarius/sticky-window-snapping.git`).
+2. Change into the folder, and run `kpackagetool-install.bash` (click on the file > *Execute*, or `./kpackagetooll-install.sh`).
+
+## Configuration
+
+*System Settings* > *Window Management* > *KWin scripts* > settings wheel for the script.
+
+You may need to disable and re-enable the script (using the checkbox) in order for the changes to take effect.
+
 <hr>
 
 KWin script to let snapped window edges stick together when one window is resized.

--- a/kpackagetool-install.bash
+++ b/kpackagetool-install.bash
@@ -2,7 +2,7 @@
 
 set -Ceux
 
-kpackagetool5 --install package
+kpackagetool5 --install package || kpackagetool --upgrade package
 
 mkdir --parents --verbose ~/.local/share/kservices5/
 ln --relative --symbolic --verbose  \

--- a/package/contents/code/main.js
+++ b/package/contents/code/main.js
@@ -32,7 +32,7 @@ var config = {
 	opacityOfSnapped: 0.8,
 	opacityOfUnaffected: 0.2,
 	gap: 0,
-        threshold: 0
+    threshold: 0
 };
 var enabledCurrently = config.enabledUsually;
 
@@ -84,7 +84,7 @@ function loadConfig() {
 	config.opacityOfUnaffected      = 0.01 *  readConfig("opacityOfUnaffected"     , 100 * config.opacityOfUnaffected     );
 	config.gap                      = 1    *  readConfig("gap"                     ,       config.gap                     );
 	config.threshold                = 1    *  readConfig("threshold"               ,       config.threshold               );
-        config.threshold += config.gap;
+    config.threshold += config.gap;
 }
 
 function connectClient(client) {
@@ -126,7 +126,7 @@ function clientStartUserMovedResized(client) {
 	}
 
 	if (!enabledCurrently) return;
-	if (!client.resize) return;
+	// if (!client.resize) return;
 	snaps.length = 0;
 	ignoreds.length = 0;
 	firstClientStepUserMovedResized = true
@@ -196,7 +196,7 @@ function clientStartUserMovedResized(client) {
 		if (snap.lr || snap.ll || snap.rl || snap.rr || snap.tb || snap.tt || snap.bt || snap.bb) {
 			if (!config.liveUpdate) {
 				if (c.minimized) {
-					snap.minimizeWhenFinished = true;
+					// snap.minimizeWhenFinished = true;
 					c.minimized = false;
 				}
 				snap.opacity = config.opacityOfSnapped;
@@ -257,7 +257,7 @@ function clientResized(client, rect) {
 		if (resizedClientInfo.bMoved && s.bb) moveBto(g, rect.y + rect.height, 0);
 		if (setGeometry(s.client, g, s.lr || s.rr, s.tb || s.bb)) {
 			if (!s.minimizeWhenFinished && s.client.minimized) {
-				s.minimizeWhenFinished = true;
+				// s.minimizeWhenFinished = true;
 				s.client.minimized = false;
 			}
 			if (s.opacity !== config.opacityOfSnapped) {

--- a/package/contents/code/main.js
+++ b/package/contents/code/main.js
@@ -32,7 +32,7 @@ var config = {
 	opacityOfSnapped: 0.8,
 	opacityOfUnaffected: 0.2,
 	gap: 0,
-    threshold: 0
+        threshold: 0
 };
 var enabledCurrently = config.enabledUsually;
 
@@ -82,9 +82,9 @@ function loadConfig() {
 	config.liveUpdate               = true == readConfig("liveUpdate"              ,       config.liveUpdate              );
 	config.opacityOfSnapped         = 0.01 *  readConfig("opacityOfSnapped"        , 100 * config.opacityOfSnapped        );
 	config.opacityOfUnaffected      = 0.01 *  readConfig("opacityOfUnaffected"     , 100 * config.opacityOfUnaffected     );
-	config.gap                      = 1    *             readConfig("gap"                     ,       config.gap               );
+	config.gap                      = 1    *  readConfig("gap"                     ,       config.gap                     );
 	config.threshold                = 1    *  readConfig("threshold"               ,       config.threshold               );
-    config.threshold += config.gap;
+        config.threshold += config.gap;
 }
 
 function connectClient(client) {

--- a/package/contents/code/main.js
+++ b/package/contents/code/main.js
@@ -31,7 +31,8 @@ var config = {
 	liveUpdate: true,
 	opacityOfSnapped: 0.8,
 	opacityOfUnaffected: 0.2,
-	threshold: 0
+	gap: 0,
+    threshold: 0
 };
 var enabledCurrently = config.enabledUsually;
 
@@ -81,7 +82,9 @@ function loadConfig() {
 	config.liveUpdate               = true == readConfig("liveUpdate"              ,       config.liveUpdate              );
 	config.opacityOfSnapped         = 0.01 *  readConfig("opacityOfSnapped"        , 100 * config.opacityOfSnapped        );
 	config.opacityOfUnaffected      = 0.01 *  readConfig("opacityOfUnaffected"     , 100 * config.opacityOfUnaffected     );
+	config.gap                      = 1    *             readConfig("gap"                     ,       config.gap               );
 	config.threshold                = 1    *  readConfig("threshold"               ,       config.threshold               );
+    config.threshold += config.gap;
 }
 
 function connectClient(client) {
@@ -244,14 +247,14 @@ function clientResized(client, rect) {
 		var s = snaps[i];
 		var og = s.originalGeometry;
 		var g = {x: og.x, y: og.y, width: og.width, height: og.height};
-		if (resizedClientInfo.lMoved && s.lr) moveRto(g, rect.x);
-		if (resizedClientInfo.lMoved && s.ll) moveLto(g, rect.x);
-		if (resizedClientInfo.rMoved && s.rl) moveLto(g, rect.x + rect.width);
-		if (resizedClientInfo.rMoved && s.rr) moveRto(g, rect.x + rect.width);
-		if (resizedClientInfo.tMoved && s.tb) moveBto(g, rect.y);
-		if (resizedClientInfo.tMoved && s.tt) moveTto(g, rect.y);
-		if (resizedClientInfo.bMoved && s.bt) moveTto(g, rect.y + rect.height);
-		if (resizedClientInfo.bMoved && s.bb) moveBto(g, rect.y + rect.height);
+		if (resizedClientInfo.lMoved && s.lr) moveRto(g, rect.x, config.gap);
+		if (resizedClientInfo.lMoved && s.ll) moveLto(g, rect.x, 0);
+		if (resizedClientInfo.rMoved && s.rl) moveLto(g, rect.x + rect.width, config.gap);
+		if (resizedClientInfo.rMoved && s.rr) moveRto(g, rect.x + rect.width, 0);
+		if (resizedClientInfo.tMoved && s.tb) moveBto(g, rect.y, config.gap);
+		if (resizedClientInfo.tMoved && s.tt) moveTto(g, rect.y, 0);
+		if (resizedClientInfo.bMoved && s.bt) moveTto(g, rect.y + rect.height, config.gap);
+		if (resizedClientInfo.bMoved && s.bb) moveBto(g, rect.y + rect.height, 0);
 		if (setGeometry(s.client, g, s.lr || s.rr, s.tb || s.bb)) {
 			if (!s.minimizeWhenFinished && s.client.minimized) {
 				s.minimizeWhenFinished = true;
@@ -278,22 +281,22 @@ function clientResized(client, rect) {
 	}
 }
 
-function moveLto(rect, x) {
-	rect.width += rect.x - x;
-	rect.x = x;
+function moveLto(rect, x, diff) {
+	rect.width += rect.x - x - diff;
+	rect.x = x + diff;
 }
 
-function moveRto(rect, x) {
-	rect.width = x - rect.x;
+function moveRto(rect, x, diff) {
+	rect.width = x - rect.x - diff;
 }
 
-function moveTto(rect, y) {
-	rect.height += rect.y - y;
-	rect.y = y;
+function moveTto(rect, y, diff) {
+	rect.height += rect.y - y - diff;
+	rect.y = y + diff;
 }
 
-function moveBto(rect, y) {
-	rect.height = y - rect.y;
+function moveBto(rect, y, diff) {
+	rect.height = y - rect.y - diff;
 }
 
 /* Rename properties of QSize to `w` and `h`.

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -29,7 +29,10 @@
     <entry name="opacityOfUnaffected" type="string">
       <default>20</default>
     </entry>
-    <entry name="threshold" type="string">
+    <entry name="gap" type="int">
+      <default>0</default>
+    </entry>
+    <entry name="threshold" type="int">
       <default>0</default>
     </entry>
   </group>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -248,6 +248,18 @@
    <slot>setValue(int)</slot>
   </connection>
   <connection>
+   <sender>kcfg_gap</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>slider_gap</receiver>
+   <slot>setValue(int)</slot>
+  </connection>
+  <connection>
+   <sender>slider_gap</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>kcfg_gap</receiver>
+   <slot>setValue(int)</slot>
+  </connection>
+  <connection>
    <sender>kcfg_threshold</sender>
    <signal>valueChanged(int)</signal>
    <receiver>slider_threshold</receiver>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -95,13 +95,40 @@
       </widget>
      </item>
      <item row="2" column="0">
+     <widget class="QLabel" name="label_gap">
+      <property name="text">
+       <string>gap between windows:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QSpinBox" name="kcfg_gap">
+      <property name="suffix">
+       <string> px</string>
+      </property>
+      <property name="maximum">
+       <number>100</number>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="2">
+     <widget class="QSlider" name="slider_gap">
+      <property name="maximum">
+       <number>100</number>
+      </property>
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+     <item row="3" column="0">
       <widget class="QLabel" name="label_threshold">
        <property name="text">
         <string>threshold:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QSpinBox" name="kcfg_threshold">
        <property name="suffix">
         <string> px</string>
@@ -111,7 +138,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
+     <item row="3" column="2">
       <widget class="QSlider" name="slider_threshold">
        <property name="maximum">
         <number>100</number>

--- a/package/metadata.desktop
+++ b/package/metadata.desktop
@@ -15,7 +15,7 @@ X-KDE-PluginInfo-Depends=
 X-KDE-PluginInfo-License=GPL
 X-KDE-ServiceTypes=KWin/Script,KCModule
 
-X-KDE-Library=kwin/effects/configs/kcm_kwin4_genericscripted
+X-KDE-ConfigModule=kwin/effects/configs/kcm_kwin4_genericscripted
 X-KDE-PluginKeyword=sticky-window-snapping
 X-KDE-ParentComponents=sticky-window-snapping
 

--- a/package/metadata.desktop
+++ b/package/metadata.desktop
@@ -19,4 +19,6 @@ X-KDE-ConfigModule=kwin/effects/configs/kcm_kwin4_genericscripted
 X-KDE-PluginKeyword=sticky-window-snapping
 X-KDE-ParentComponents=sticky-window-snapping
 
+X-KDE-PluginInfo-EnabledByDefault=true
+
 Type=Service

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -1,0 +1,26 @@
+{
+	"KPlugin": {
+		"Authors": [
+			{
+				"Email": "sticky-window-snapping@derflupp.e4ward.com",
+				"Name": "Toni Dietze"
+			}
+		],
+		"Category": "Windows and Tasks",
+		"Description": "Let snapped window edges stick together when one window is resized.",
+		"Icon": "preferences-system-windows-script-test",
+		"Id": "sticky-window-snapping",
+		"License": "GPL",
+		"Name": "Sticky Window Snapping",
+		"ServiceTypes": [
+			"KWin/Script",
+			"KCModule"
+		],
+		"Version": "1.0.1",
+		"Website": "https://github.com/Flupp/sticky-window-snapping"
+	},
+	"X-KDE-ConfigModule": "kwin/effects/configs/kcm_kwin4_genericscripted",
+	"X-KDE-PluginKeyword": "sticky-window-snapping",
+	"X-Plasma-API": "javascript",
+	"X-Plasma-MainScript": "code/main.js"
+} 

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -16,6 +16,7 @@
 			"KWin/Script",
 			"KCModule"
 		],
+		"EnabledByDefault": "true",
 		"Version": "1.0.1",
 		"Website": "https://github.com/Flupp/sticky-window-snapping"
 	},
@@ -23,4 +24,4 @@
 	"X-KDE-PluginKeyword": "sticky-window-snapping",
 	"X-Plasma-API": "javascript",
 	"X-Plasma-MainScript": "code/main.js"
-} 
+}


### PR DESCRIPTION
Nice script, thank you for this!

I created my own fork so as to make sticky window snapping compatible with tile gaps: [https://github.com/nclarius/tile-gaps](https://github.com/nclarius/tile-gaps)
The user can set a size for a universal gap between adjacent windows in the configuration, and these gaps will be properly retained when resizing neighboring windows.

Would you consider adopting these changes so that users can use both our scripts in parallel?